### PR TITLE
Using toASCIIBytes / fromASCIIBytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ cabal-dev
 *.chi
 *.chs.h
 .virthualenv
+/default.nix
+/shell.nix
+/uuid-aeson.nix

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@ cabal-dev
 *.chi
 *.chs.h
 .virthualenv
-/default.nix
-/shell.nix
-/uuid-aeson.nix

--- a/src/Data/UUID/Aeson.hs
+++ b/src/Data/UUID/Aeson.hs
@@ -11,7 +11,7 @@ instance ToJSON UUID where toJSON = String . T.decodeUtf8 . toASCIIBytes
 
 instance FromJSON UUID where
   parseJSON json@(String t) = 
-    case fromASCIIBytes (T.encodeUtf8 uuidString) of
+    case fromASCIIBytes (T.encodeUtf8 t) of
       Just uuid -> pure uuid 
       Nothing   -> typeMismatch "UUID" json 
   parseJSON unknown = typeMismatch "UUID" unknown

--- a/uuid-aeson.cabal
+++ b/uuid-aeson.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                uuid-aeson
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            Aeson types for UUID instances.
 -- description:         
 license:             BSD3

--- a/uuid-aeson.cabal
+++ b/uuid-aeson.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                uuid-aeson
-version:             0.1.1.0
+version:             0.1.0.1
 synopsis:            Aeson types for UUID instances.
 -- description:         
 license:             BSD3

--- a/uuid-aeson.cabal
+++ b/uuid-aeson.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                uuid-aeson
-version:             0.2.0.0
+version:             0.1.1.0
 synopsis:            Aeson types for UUID instances.
 -- description:         
 license:             BSD3
@@ -21,4 +21,4 @@ library
   build-depends:     base >= 4,
                      text,  
                      aeson, 
-                     uuid >= 1
+                     uuid >= 1.3


### PR DESCRIPTION
I'm going to be using `uuid`s heavily, converting to `String` has larger thunk allocation (~4x larger space inflation) than `ByteString`. Would rather use an array as the intermediate data structure, as opposed to a linked list. Who knows though, GHC might be removing it altogether, but just in case. I'm a little paranoid.