### PR TITLE
Depend on uuid-types

### DIFF
--- a/src/Data/UUID/Aeson.hs
+++ b/src/Data/UUID/Aeson.hs
@@ -1,7 +1,7 @@
 module Data.UUID.Aeson where
 
 import Control.Applicative (pure)
-import Data.UUID (UUID, fromASCIIBytes, toASCIIBytes)
+import Data.UUID.Types (UUID, fromASCIIBytes, toASCIIBytes)
 import Data.Aeson (ToJSON,FromJSON, toJSON, parseJSON) 
 import Data.Aeson.Types (Value(String), typeMismatch)
 import qualified Data.Text.Encoding as T

--- a/uuid-aeson.cabal
+++ b/uuid-aeson.cabal
@@ -21,4 +21,4 @@ library
   build-depends:     base >= 4,
                      text,  
                      aeson, 
-                     uuid >= 1.3
+                     uuid-types


### PR DESCRIPTION
The uuid-types package provides the same types with less dependencies. The uuid package uses uuid-types.

My primary motivation is to build this package with GHCJS.